### PR TITLE
Ignore pull request commit message

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,8 @@ language: python
 python:
   - "3.6"
 
+if: type != pull_request
+
 cache:
   directories:
     - $HOME/nltk_data


### PR DESCRIPTION
Don't let TravisCI try to validate the pull request commit message
because it is in the form of 'Merge SHA to SHA' and therefore it
is typically for too long for a valid subject.