### PR TITLE
Allow conventional commits

### DIFF
--- a/.github/workflows/test-action.yml
+++ b/.github/workflows/test-action.yml
@@ -1,0 +1,22 @@
+name: Python package
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+          python -m textblob.download_corpora
+      - name: Run tests
+        run: |
+          python -m pytest bad_commit_message_blocker_tests.py

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__
+.venv

--- a/README.md
+++ b/README.md
@@ -94,4 +94,6 @@ jobs:
           body_limit: 100
           # Optionally set the remote branch name to merge (default `master`)
           remote_branch: dev
+          # Optionally allow "conventional commits" (default `false`)
+          allow_conventional_commits: true
 ```

--- a/action.yml
+++ b/action.yml
@@ -9,6 +9,10 @@ inputs:
     description: 'The maximum allowed length for a line in the commit body'
     required: true
     default: 72
+  conventional_commit:
+    description: 'Whether to allow conventional commits, e.g. "feat: add new feature"'
+    required: false
+    default: false
   remote_branch:
     description: 'The name of the remote branch you are trying to merge with'
     required: true

--- a/bad_commit_message_blocker.py
+++ b/bad_commit_message_blocker.py
@@ -1,4 +1,4 @@
-'''
+"""
 The `bad commit message blocker` intends to inhibit commits with bad
 messages from getting merged into a project.
 
@@ -14,7 +14,8 @@ from limitations of the (default) NLP parser the NLTK library utilizes.
 The final rule (#7) about explaining what and why instead of how in the
 body of a commit message, very subjective and therefore is left up to
 the code reviewer to ensure it is being adhered to.
-'''
+"""
+
 import argparse
 import sys
 from textblob import TextBlob
@@ -24,14 +25,14 @@ DEFAULT_BODY_LIMIT = 72
 
 
 class CliColors:
-    HEADER = '\033[95m'
-    OKBLUE = '\033[94m'
-    OKGREEN = '\033[92m'
-    WARNING = '\033[93m'
-    FAIL = '\033[91m'
-    ENDC = '\033[0m'
-    BOLD = '\033[1m'
-    UNDERLINE = '\033[4m'
+    HEADER = "\033[95m"
+    OKBLUE = "\033[94m"
+    OKGREEN = "\033[92m"
+    WARNING = "\033[93m"
+    FAIL = "\033[91m"
+    ENDC = "\033[0m"
+    BOLD = "\033[1m"
+    UNDERLINE = "\033[4m"
 
 
 def check_subject_is_separated_from_body(commit_message):
@@ -50,8 +51,9 @@ def check_subject_is_separated_from_body(commit_message):
 def check_subject_is_not_too_long(commit_message, subject_limit):
     lines = commit_message.splitlines()
     check_result = len(lines[0]) <= subject_limit
-    print_result(check_result, "Limit the subject line to " +
-                 str(subject_limit) + " characters")
+    print_result(
+        check_result, "Limit the subject line to " + str(subject_limit) + " characters"
+    )
 
     return check_result
 
@@ -87,8 +89,7 @@ def check_subject_uses_imperative(commit_message):
     third_person_prefix = "It "
     words_in_third_person_prefix_blob = len(third_person_prefix.split())
     non_third_person_prefix = "You "
-    words_in_non_third_person_prefix_blob = len(
-        non_third_person_prefix.split())
+    words_in_non_third_person_prefix_blob = len(non_third_person_prefix.split())
     # Turn the first character into a lowercase so to make it easier for
     # the parser to determine whether the word is a verb and its tense
     first_character_in_lowercase = first_line[0].lower()
@@ -96,8 +97,12 @@ def check_subject_uses_imperative(commit_message):
     third_person_blob = TextBlob(third_person_prefix + first_line)
     non_third_person_blob = TextBlob(non_third_person_prefix + first_line)
 
-    first_word, third_person_result = third_person_blob.tags[words_in_third_person_prefix_blob]
-    _, non_third_person_result = non_third_person_blob.tags[words_in_non_third_person_prefix_blob]
+    first_word, third_person_result = third_person_blob.tags[
+        words_in_third_person_prefix_blob
+    ]
+    _, non_third_person_result = non_third_person_blob.tags[
+        words_in_non_third_person_prefix_blob
+    ]
 
     # We need to determine whether the first word is a non-third person verb
     # when parsed in a non-third person blob. However, there were some
@@ -107,8 +112,13 @@ def check_subject_uses_imperative(commit_message):
     # third person, when parsed in the third person blob.
     # So, we ultimately check if the verb ends with an 's' which is a pretty
     # good indicator of a third person, simple present tense verb.
-    check_result = non_third_person_result == non_third_person_singular_present_verb and (
-        third_person_result != third_person_singular_present_verb or not first_word.endswith("s"))
+    check_result = (
+        non_third_person_result == non_third_person_singular_present_verb
+        and (
+            third_person_result != third_person_singular_present_verb
+            or not first_word.endswith("s")
+        )
+    )
     print_result(check_result, "Use the imperative mood in the subject line")
 
     return check_result
@@ -121,66 +131,75 @@ def check_body_lines_are_not_too_long(commit_message, body_limit):
         if len(line) > body_limit:
             check_result = False
             break
-    print_result(check_result, "Wrap the body at " +
-                 str(body_limit) + " characters")
+    print_result(check_result, "Wrap the body at " + str(body_limit) + " characters")
 
     return check_result
 
 
 def check_body_explains_what_and_why(commit_message):
     what_vs_how_rule = "Use the body to explain what and why vs. how"
-    print("[" + CliColors.OKBLUE + "  NA  " +
-          CliColors.ENDC + "] " + what_vs_how_rule)
+    print("[" + CliColors.OKBLUE + "  NA  " + CliColors.ENDC + "] " + what_vs_how_rule)
 
     return True
 
 
 def print_result(check_passed, rule):
-    print("[" + (CliColors.OKGREEN +
-                 "PASSED" if check_passed else CliColors.FAIL + "FAILED") + CliColors.ENDC + "] " + rule)
+    print(
+        "["
+        + (CliColors.OKGREEN + "PASSED" if check_passed else CliColors.FAIL + "FAILED")
+        + CliColors.ENDC
+        + "] "
+        + rule
+    )
 
 
-def check(commit_message, subject_limit=DEFAULT_SUBJECT_LIMIT, body_limit=DEFAULT_BODY_LIMIT):
-    all_rules_verified = check_subject_is_separated_from_body(
-        commit_message)
-    all_rules_verified &= check_subject_is_not_too_long(
-        commit_message, subject_limit)
+def check(
+    commit_message, subject_limit=DEFAULT_SUBJECT_LIMIT, body_limit=DEFAULT_BODY_LIMIT
+):
+    all_rules_verified = check_subject_is_separated_from_body(commit_message)
+    all_rules_verified &= check_subject_is_not_too_long(commit_message, subject_limit)
     all_rules_verified &= check_subject_is_capitalized(commit_message)
-    all_rules_verified &= check_subject_does_not_end_with_period(
-        commit_message)
+    all_rules_verified &= check_subject_does_not_end_with_period(commit_message)
     all_rules_verified &= check_subject_uses_imperative(commit_message)
-    all_rules_verified &= check_body_lines_are_not_too_long(
-        commit_message, body_limit)
+    all_rules_verified &= check_body_lines_are_not_too_long(commit_message, body_limit)
     all_rules_verified &= check_body_explains_what_and_why(commit_message)
 
     return all_rules_verified
 
 
 def main():
-    parser_description = "Bad commit message blocker: Avoid bad commit messages in your repository"
+    parser_description = (
+        "Bad commit message blocker: Avoid bad commit messages in your repository"
+    )
     parser = argparse.ArgumentParser(description=parser_description)
-    parser.add_argument("--message",
-                        help="The commit message to check",
-                        required=True)
-    parser.add_argument("--subject-limit",
-                        help="The maximum allowed length for a commit subject",
-                        default=DEFAULT_SUBJECT_LIMIT)
-    parser.add_argument("--body-limit",
-                        help="The maximum allowed length for a line in the commit body",
-                        default=DEFAULT_BODY_LIMIT)
+    parser.add_argument("--message", help="The commit message to check", required=True)
+    parser.add_argument(
+        "--subject-limit",
+        help="The maximum allowed length for a commit subject",
+        default=DEFAULT_SUBJECT_LIMIT,
+    )
+    parser.add_argument(
+        "--body-limit",
+        help="The maximum allowed length for a line in the commit body",
+        default=DEFAULT_BODY_LIMIT,
+    )
     args = parser.parse_args()
 
     commit_message = args.message.strip()
-    print(CliColors.HEADER + CliColors.BOLD +
-          "Your commit message: " + CliColors.ENDC)
+    print(CliColors.HEADER + CliColors.BOLD + "Your commit message: " + CliColors.ENDC)
     print("===========================")
     print(commit_message)
     print("===========================")
-    print(CliColors.HEADER + CliColors.BOLD +
-          "Conformance to the 7 rules of a great Git commit message:" + CliColors.ENDC)
+    print(
+        CliColors.HEADER
+        + CliColors.BOLD
+        + "Conformance to the 7 rules of a great Git commit message:"
+        + CliColors.ENDC
+    )
 
-    all_rules_verified = check(commit_message, int(
-        args.subject_limit), int(args.body_limit))
+    all_rules_verified = check(
+        commit_message, int(args.subject_limit), int(args.body_limit)
+    )
 
     sys.exit(0 if all_rules_verified else 1)
 

--- a/bad_commit_message_blocker_tests.py
+++ b/bad_commit_message_blocker_tests.py
@@ -1,11 +1,12 @@
-'''
+"""
 A set of unit tests for the Bad Commit Message Blocker.
 
 The most interesting (and prone to fail) part is the imperative mood rule.
 This is why most tests are focused a round it. If you want to introduce
 improvements/changes to the script, make sure that there are no regressions
 and your newly introduced change is also covered by unit tests.
-'''
+"""
+
 import unittest
 import bad_commit_message_blocker as blocker
 
@@ -16,64 +17,83 @@ class TestCommitMessageBlocker(unittest.TestCase):
         pass
 
     def test_checkSubjectUsesImperative_WhenImperative_WillReturnTrue(self):
-        test_input = ["Refactor subsystem X for readability",
-                      "Update getting started documentation",
-                      "Remove deprecated methods",
-                      "Release version 1.0.0",
-                      "Add cool method to class"]
+        test_input = [
+            "Refactor subsystem X for readability",
+            "Update getting started documentation",
+            "Remove deprecated methods",
+            "Release version 1.0.0",
+            "Add cool method to class",
+        ]
         for input in test_input:
-            self.assertTrue(blocker.check_subject_uses_imperative(
-                input), "\"" + input + "\" did not produce the expected result")
+            self.assertTrue(
+                blocker.check_subject_uses_imperative(input),
+                '"' + input + '" did not produce the expected result',
+            )
 
     def test_checkSubjectUsesImperative_WhenThirdPerson_WillReturnFalse(self):
-        test_input = ["Refactors subsystem X for readability",
-                      "Updates getting started documentation",
-                      "Removes deprecated methods",
-                      "Releases version 1.0.0",
-                      "Adds cool method to class"]
+        test_input = [
+            "Refactors subsystem X for readability",
+            "Updates getting started documentation",
+            "Removes deprecated methods",
+            "Releases version 1.0.0",
+            "Adds cool method to class",
+        ]
         for input in test_input:
-            self.assertFalse(blocker.check_subject_uses_imperative(
-                input), "\"" + input + "\" did not produce the expected result")
+            self.assertFalse(
+                blocker.check_subject_uses_imperative(input),
+                '"' + input + '" did not produce the expected result',
+            )
 
     def test_checkSubjectUsesImperative_WhenPresentContinuous_WillReturnFalse(self):
-        test_input = ["Refactoring subsystem X for readability",
-                      "Updating getting started documentation",
-                      "Removing deprecated methods",
-                      "Releasing version 1.0.0",
-                      "Adding cool method to class"]
+        test_input = [
+            "Refactoring subsystem X for readability",
+            "Updating getting started documentation",
+            "Removing deprecated methods",
+            "Releasing version 1.0.0",
+            "Adding cool method to class",
+        ]
         for input in test_input:
-            self.assertFalse(blocker.check_subject_uses_imperative(
-                input), "\"" + input + "\" did not produce the expected result")
+            self.assertFalse(
+                blocker.check_subject_uses_imperative(input),
+                '"' + input + '" did not produce the expected result',
+            )
 
     def test_checkSubjectUsesImperative_WhenSimplePast_WillReturnFalse(self):
-        test_input = ["Refactored subsystem X for readability",
-                      "Updated getting started documentation",
-                      "Removed deprecated methods",
-                      "Released version 1.0.0",
-                      "Added cool method to class"]
+        test_input = [
+            "Refactored subsystem X for readability",
+            "Updated getting started documentation",
+            "Removed deprecated methods",
+            "Released version 1.0.0",
+            "Added cool method to class",
+        ]
         for input in test_input:
-            self.assertFalse(blocker.check_subject_uses_imperative(
-                input), "\"" + input + "\" did not produce the expected result")
+            self.assertFalse(
+                blocker.check_subject_uses_imperative(input),
+                '"' + input + '" did not produce the expected result',
+            )
 
     def test_checkSubjectUsesImperative_WhenRandom_WillReturnFalse(self):
-        test_input = ["Documentation is updated",
-                      "Addition of new class"]
+        test_input = ["Documentation is updated", "Addition of new class"]
         for input in test_input:
-            self.assertFalse(blocker.check_subject_uses_imperative(
-                input), "\"" + input + "\" did not produce the expected result")
+            self.assertFalse(
+                blocker.check_subject_uses_imperative(input),
+                '"' + input + '" did not produce the expected result',
+            )
 
-    def test_checkSubjectSeparateFromBody_WhenLineBetweenBodyAndSubject_WillReturnTrue(self):
+    def test_checkSubjectSeparateFromBody_WhenLineBetweenBodyAndSubject_WillReturnTrue(
+        self,
+    ):
         test_input = """Add this cool feature
 
         This cool feature is implemented because X and Y."""
-        self.assertTrue(
-            blocker.check_subject_is_separated_from_body(test_input))
+        self.assertTrue(blocker.check_subject_is_separated_from_body(test_input))
 
-    def test_checkSubjectSeparateFromBody_WhenNoLineBetweenBodyAndSubject_WillReturnFalse(self):
+    def test_checkSubjectSeparateFromBody_WhenNoLineBetweenBodyAndSubject_WillReturnFalse(
+        self,
+    ):
         test_input = """Add this cool feature
         This cool feature is implemented because X and Y."""
-        self.assertFalse(
-            blocker.check_subject_is_separated_from_body(test_input))
+        self.assertFalse(blocker.check_subject_is_separated_from_body(test_input))
 
     def test_checkSubjectNotTooLong_WhenSubjectTooLong_WillReturnFalse(self):
         test_input = "This is a very very very, really long, humongous subject for a commit message"
@@ -83,7 +103,9 @@ class TestCommitMessageBlocker(unittest.TestCase):
         test_input = "Add this neat commit message"
         self.assertTrue(blocker.check_subject_is_not_too_long(test_input, 60))
 
-    def test_checkSubjectIsCapitalized_WhenSubjectBeginsWithCapital_WillReturnTrue(self):
+    def test_checkSubjectIsCapitalized_WhenSubjectBeginsWithCapital_WillReturnTrue(
+        self,
+    ):
         test_input = "Add this cool new feature"
         self.assertTrue(blocker.check_subject_is_capitalized(test_input))
 
@@ -91,30 +113,30 @@ class TestCommitMessageBlocker(unittest.TestCase):
         test_input = "add this weird-looking commit message"
         self.assertFalse(blocker.check_subject_is_capitalized(test_input))
 
-    def test_checkSubjectDoesNotEndWithPeriod_WhenSubjectEndsWithPeriod_WillReturnFalse(self):
+    def test_checkSubjectDoesNotEndWithPeriod_WhenSubjectEndsWithPeriod_WillReturnFalse(
+        self,
+    ):
         test_input = "I am a strange person and do such things."
-        self.assertFalse(
-            blocker.check_subject_does_not_end_with_period(test_input))
+        self.assertFalse(blocker.check_subject_does_not_end_with_period(test_input))
 
-    def test_checkSubjectDoesNotEndWithPeriod_WhenSubjectEndsWithoutPeriod_WillReturnTrue(self):
+    def test_checkSubjectDoesNotEndWithPeriod_WhenSubjectEndsWithoutPeriod_WillReturnTrue(
+        self,
+    ):
         test_input = "I am a strange person and don't end commit messages with a period"
-        self.assertTrue(
-            blocker.check_subject_does_not_end_with_period(test_input))
+        self.assertTrue(blocker.check_subject_does_not_end_with_period(test_input))
 
     def test_checkBodyLinesAreNotTooLong_WhenLinesTooLong_WillReturnFalse(self):
         test_input = """Add this cool new feature
 
         But damn...
         I feel like adding some pretty huge lines and forget to insert \\n's. This is just sad!"""
-        self.assertFalse(
-            blocker.check_body_lines_are_not_too_long(test_input, 72))
+        self.assertFalse(blocker.check_body_lines_are_not_too_long(test_input, 72))
 
     def test_checkBodyLinesAreNotTooLong_WhenLinesNotTooLong_WillReturnTrue(self):
         test_input = """Add this cool new feature
 
         And nicely explain why it was added."""
-        self.assertTrue(
-            blocker.check_body_lines_are_not_too_long(test_input, 72))
+        self.assertTrue(blocker.check_body_lines_are_not_too_long(test_input, 72))
 
     def test_checkBodyExplainsWhatAndWhy_WhenCalled_WillReturnTrue(self):
         # We cannot currently check this, so we always return true
@@ -123,5 +145,5 @@ class TestCommitMessageBlocker(unittest.TestCase):
         self.assertTrue(blocker.check_body_explains_what_and_why(test_input))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     unittest.main()

--- a/bad_commit_message_blocker_tests.py
+++ b/bad_commit_message_blocker_tests.py
@@ -144,6 +144,16 @@ class TestCommitMessageBlocker(unittest.TestCase):
         test_input = "Something that does not matter"
         self.assertTrue(blocker.check_body_explains_what_and_why(test_input))
 
+    def test_stripPrefix_WhenColonInMessage_WillReturnEverythingAfterColon(self):
+        test_input = "feat: add new feature"
+        expected_output = "add new feature"
+        self.assertEqual(blocker.strip_prefix(test_input), expected_output)
+
+    def test_stripPrefix_WhenNoColonInMessage_WillReturnWholeMessage(self):
+        test_input = "add new feature"
+        expected_output = "add new feature"
+        self.assertEqual(blocker.strip_prefix(test_input), expected_output)
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,5 +20,6 @@ while read -r commit_hash; do
     python3 $script_dir/bad_commit_message_blocker.py \
         --message "${commit_message}" \
         --subject-limit "${INPUT_SUBJECT_LIMIT}" \
-        --body-limit "${INPUT_BODY_LIMIT}"
+        --body-limit "${INPUT_BODY_LIMIT}" \
+        --conventional-commit "${INPUT_CONVENTIONAL_COMMIT}"
 done <<< "$commits_since_master"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+textblob==0.18.0.post0
+pytest==8.3.2


### PR DESCRIPTION
Some projects use 'conventional commits' so let's make it easier for them to use this Action, by ignoring the subject/tag.